### PR TITLE
Add CLI tests for argument validation

### DIFF
--- a/tests/cli.test.js
+++ b/tests/cli.test.js
@@ -1,0 +1,41 @@
+const path = require('path');
+const { spawn } = require('child_process');
+
+function runCli(args = []) {
+  return new Promise((resolve) => {
+    const nodePath = process.execPath;
+    const cliPath = path.join(__dirname, '..', 'src', 'index.js');
+    const child = spawn(nodePath, [cliPath, ...args]);
+
+    let stdout = '';
+    let stderr = '';
+
+    child.stdout.on('data', (data) => {
+      stdout += data.toString();
+    });
+
+    child.stderr.on('data', (data) => {
+      stderr += data.toString();
+    });
+
+    child.on('close', (code) => {
+      resolve({ code, stdout, stderr });
+    });
+  });
+}
+
+describe('CLI Argument Validation', () => {
+  test('running without arguments exits with error and shows help', async () => {
+    const result = await runCli();
+    expect(result.code).not.toBe(0);
+    const output = result.stdout + result.stderr;
+    expect(output).toMatch(/usage:/i);
+    expect(output).toMatch(/url-to-md/);
+  });
+
+  test('conflicting viewport options exits with error', async () => {
+    const result = await runCli(['http://example.com', '--mobile', '--desktop']);
+    expect(result.code).not.toBe(0);
+    expect(result.stderr).toMatch(/only one viewport preset/i);
+  });
+});


### PR DESCRIPTION
## Summary
- add tests exercising CLI behavior for missing args and conflicting viewport presets

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68748228fb1883279000ba42c5e6550b